### PR TITLE
Add davmail oauth properties

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,13 @@ RUN mv -v /davmail-code/target/davmail-*.jar /target/davmail/
 RUN cd /target/davmail\
  && ln -s davmail-*.jar davmail.jar
 
+RUN sed -i '/#davmail.oauth.tokenFilePath=/s/^#//g' /davmail-code/src/etc/davmail.properties
+RUN sed -i '/davmail.oauth.tokenFilePath/a \
+# update stored refresh token after each authentication \n\
+davmail.oauth.persistToken= \n\
+davmail.oauth.clientId= \n\
+davmail.oauth.redirectUri= \' /davmail-code/src/etc/davmail.properties
+
 # Make entrypoint
 COPY entrypoint-generator.sh /davmail-entrypoint/generator
 RUN /davmail-entrypoint/generator /davmail-code/src/etc/davmail.properties > /target/entrypoint\

--- a/tests/compose-sut.yaml
+++ b/tests/compose-sut.yaml
@@ -74,6 +74,11 @@ services:
       - DAVMAIL_SSL_KEYSTOREPASS=
       - DAVMAIL_SSL_KEYPASS=
 
+      - DAVMAIL_OAUTH_TOKENFILEPATH=
+      - DAVMAIL_OAUTH_PERSISTTOKEN=
+      - DAVMAIL_OAUTH_CLIENTID=d3590ed6-52b3-4102-aeff-aad2292ab01c
+      - DAVMAIL_OAUTH_REDIRECTURI=urn:ietf:wg:oauth:2.0:oob
+
 # Accept specified certificate even if invalid according to trust store
       - DAVMAIL_SERVER_CERTIFICATE_HASH=
 

--- a/tests/davmail.properties.example
+++ b/tests/davmail.properties.example
@@ -21,6 +21,14 @@ davmail.ldapPort=1389
 davmail.popPort=1110
 davmail.smtpPort=1025
 
+# Optional: separate file to store Oauth tokens
+davmail.oauth.tokenFilePath=
+# update stored refresh token after each authentication
+davmail.oauth.persistToken=
+# Required if admin won't provide approval
+davmail.oauth.clientId=
+davmail.oauth.redirectUri=
+
 #############################################################
 # Network settings
 


### PR DESCRIPTION
I was reading it seems `DAVMAIL_PROPERTIES_FILE` by default uses [`davmail.properties.example`](https://github.com/kran0/davmail-docker/blob/master/entrypoint-generator.sh#L12).

The container should allow these OAuth options to be set. They're only useful if the mode is set to `O365Manual`. Sometimes admin [won't allow anything but Outlook](https://man.sr.ht/~rjarry/aerc/providers/microsoft.md#office365-with-imap-disabled), and that's when you need to [set that](https://github.com/mguessan/davmail/issues/321#issuecomment-1867072418).

I would like to be able to set these environmental variables when running davmail.

```
DAVMAIL_MODE=O365Manual
DAVMAIL_OAUTH_CLIENTID=d3590ed6-52b3-4102-aeff-aad2292ab01c
DAVMAIL_OAUTH_REDIRECTURI=urn:ietf:wg:oauth:2.0:oob
```

Not sure if this is the way to do this? I just had a bit of a guess.