### PR TITLE
Update BASE_IMAGE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=openjdk:8-jre-alpine
+ARG BASE_IMAGE=eclipse-temurin:21-jre-alpine
 FROM alpine:latest AS builder
 
 #trunk rev HEAD (may be unstable)


### PR DESCRIPTION
TLS issues with old OpenJDK 8 container.  OpenJDK container is deprecated now (only publish updates to EA versions).  21 was chosen as it's the current LTS.  JDK/JRE "distro" choice was just picked and could be swapped out for another if needed.